### PR TITLE
give better error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Below is a non-exhaustive list of Rust libraries that should be supported by `nu
 
 
 ## TODO
-- [ ] polish serialization error messages
+- [x] polish serialization error messages
 - [ ] add documentation
 
 [`bincode`]: https://docs.rs/bincode/latest/bincode/

--- a/nu-serde-bin/mod.nu
+++ b/nu-serde-bin/mod.nu
@@ -210,7 +210,11 @@ export def "deserialize" [schema]: [ binary -> any ] {
     let span = (metadata $in).span
     if $res.err != {} {
         let err = if $res.n == 0 {
-            $res.err | update label.span (metadata $schema).span
+            if $res.err.label.span? != null {
+                $res.err | update label.span (metadata $schema).span
+            } else {
+                $res.err
+            }
         } else {
             $res.err
         }

--- a/nu-serde-bin/mod.nu
+++ b/nu-serde-bin/mod.nu
@@ -35,7 +35,7 @@ def "deserialize vec" [size: int]: [ binary -> record<deser: list<binary>, n: in
     if ($elements | bytes length) < ($nb_elements * $size) {
         return {
             deser: null,
-            n: null,
+            n: 8,
             err: {
                 msg: $"(ansi red_bold)deser_vec::invalid_binary(ansi reset)",
                 help: $"expected at least (ansi cyan)($nb_elements * $size)(ansi reset) bytes, found (ansi yellow)($elements | bytes length)(ansi reset): (ansi purple)($elements)(ansi reset)",
@@ -132,7 +132,7 @@ export def "deserialize" [schema]: [ binary -> any ] {
                                 $res | upsert err.label.text { |it|
                                     $it.err.label?.text?
                                         | default ""
-                                        | $in + $"error at byte (ansi red)($offset)(ansi purple) ($bin | bytes at ($offset)..($offset)) in input binary"
+                                        | $in + $"error at byte (ansi red)($offset + $res.n)(ansi purple) ($bin | bytes at ($offset)..($offset)) in input binary"
                                 }
                             )
                         }
@@ -145,7 +145,7 @@ export def "deserialize" [schema]: [ binary -> any ] {
                                 $res | upsert err.label.text { |it|
                                     $it.err.label?.text?
                                         | default ""
-                                        | $in + $"error at byte (ansi red)($offset)(ansi purple) ($bin | bytes at ($offset)..($offset)) in input binary"
+                                        | $in + $"error at byte (ansi red)($offset + $res.n)(ansi purple) ($bin | bytes at ($offset)..($offset)) in input binary"
                                 }
                             )
                         }

--- a/nu-serde-bin/mod.nu
+++ b/nu-serde-bin/mod.nu
@@ -127,39 +127,27 @@ export def "deserialize" [schema]: [ binary -> any ] {
                 match $s.type {
                     "vec" => {
                         let res = $bin | skip $offset | deserialize vec $s.size
-                        print "test"
-                        print ($res | te)
                         if $res.err != {} {
-                            print "err"
-                            let foo = (
+                            return (
                                 $res | upsert err.label.text { |it|
                                     $it.err.label?.text?
                                         | default ""
                                         | $in + $"error at byte (ansi red)($offset)(ansi purple) ($bin | bytes at ($offset)..($offset)) in input binary"
                                 }
                             )
-                            print "ok"
-                            print $foo
-                            return $foo
                         }
                         return $res
                     },
                     "int" => {
                         let res = $bin | skip $offset | deserialize int $s.size
-                        print "test"
-                        print ($res | te)
                         if $res.err != {} {
-                            print "err"
-                            let foo = (
+                            return (
                                 $res | upsert err.label.text { |it|
                                     $it.err.label?.text?
                                         | default ""
                                         | $in + $"error at byte (ansi red)($offset)(ansi purple) ($bin | bytes at ($offset)..($offset)) in input binary"
                                 }
                             )
-                            print "ok"
-                            print $foo
-                            return $foo
                         }
                         return $res
                     },
@@ -186,8 +174,6 @@ export def "deserialize" [schema]: [ binary -> any ] {
 
                     let res = $bin | aux $curr.v $it.1
                     if $res.err != {} {
-                        $res.err | table --expand | print
-                        print $it.1
                         { out: { deser: null, n: $it.1, err: $res.err } }
                     } else {
                         let deser = $it.2 | merge { $curr.k: $res.deser }
@@ -222,10 +208,7 @@ export def "deserialize" [schema]: [ binary -> any ] {
 
     let res = $in | aux $schema 0
     let span = (metadata $in).span
-    print $res
     if $res.err != {} {
-        print $"n: ($res.n)"
-        print ($res.err | te)
         let err = if $res.n == 0 {
             $res.err | update label.span (metadata $schema).span
         } else {

--- a/nu-serde-bin/mod.nu
+++ b/nu-serde-bin/mod.nu
@@ -285,7 +285,7 @@ export def "serialize" [schema]: [ any -> binary ] {
                         if $res.err != {} {
                             return (
                                 $res | insert err.label {
-                                    text: $"woopsie",
+                                    text: $"some error",
                                     span: (metadata $schema).span,
                                 }
                             )


### PR DESCRIPTION
## some examples
> the examples have been generated with the following Bash script
> ```bash
> #!/usr/bin/env bash
> 
> USE="use ./nu-serde-bin/ *"
> 
> cases=(
>     "0x[01 02] | deserialize 'djakwl'"
>     "0x[01 02] | deserialize 'djakwl:123'"
>     "0x[01 02] | deserialize 'int:24'"
>     "0x[01 02] | deserialize 'vec:16'"
>     "0x[02 00 00 00  00 00 00 00] | deserialize 'vec:160'"
>     "0x[01 02] | deserialize { x: 'djakwl' }"
>     "0x[01 02] | deserialize { x: { a: 'int:8', y: 'djakwl' } }"
>
>     "123 | serialize 'djakwl'"
>     "123 | serialize 'djakwl:123'"
>     "123 | serialize 'vec:16'"
>     "[0x[01 02], 0x[03]] | serialize 'vec:16'"
>     "{ x: 123 } | serialize { x: 'djakwl' }"
>     "{ x: { a: 123, y: 456 } } | serialize { x: { a: 'int:8', y: 'djakwl' } }"
> )
> for case in "${cases[@]}"; do
>     echo "\`\`\`nushell"
>     echo $case
>     echo "\`\`\`"
>     echo "\`\`\`"
>     nu -c "$USE;
> 
> $case"
>     echo "\`\`\`"
>     echo ""
>     echo "---"
>     echo ""
> done
> ```

```nushell
0x[01 02] | deserialize 'djakwl'
```
```
Error:   × invalid_schema
   ╭─[source:3:25]
 2 │
 3 │ 0x[01 02] | deserialize 'djakwl'
   ·                         ────┬───
   ·                             ╰── schema is malformed
   ╰────
  help: expected format to be {type}:{size}, found djakwl
```
---
```nushell
0x[01 02] | deserialize 'djakwl:123'
```
```
Error:   × invalid_schema
   ╭─[source:3:25]
 2 │
 3 │ 0x[01 02] | deserialize 'djakwl:123'
   ·                         ──────┬─────
   ·                               ╰── schema is malformed
   ╰────
  help: expected size to be a multiple of 8, found 123
```
---
```nushell
0x[01 02] | deserialize 'int:24'
```
```
Error:   × deser_int::invalid_binary
   ╭─[source:3:25]
 2 │
 3 │ 0x[01 02] | deserialize 'int:24'
   ·                         ────┬───
   ·                             ╰─┤ error at byte 0 in input binary
   ·                               │ context: 0x01 0x02
   ╰────
  help: expected at least 3 bytes, found 2: 0x0102
```
---
```nushell
0x[01 02] | deserialize 'vec:16'
```
```
Error:   × deser_int::invalid_binary
   ╭─[source:3:25]
 2 │
 3 │ 0x[01 02] | deserialize 'vec:16'
   ·                         ────┬───
   ·                             ╰─┤ error at byte 0 in input binary
   ·                               │ context: 0x01 0x02
   ╰────
  help: expected at least 8 bytes, found 2: 0x0102
```
---
```nushell
0x[02 00 00 00 00 00 00 00] | deserialize 'vec:160'
```
```
Error:   × deser_vec::invalid_binary
   ╭─[source:3:44]
 2 │
 3 │ 0x[02 00 00 00  00 00 00 00] | deserialize 'vec:160'
   ·                                            ────┬────
   ·                                                ╰─┤ error at byte 8 in input binary
   ·                                                  │ context: 0x000000 0x
   ╰────
  help: expected at least 40 bytes, found 0: 0x
```
---
```nushell
0x[01 02] | deserialize { x: 'djakwl' }
```
```
Error:   × invalid_schema
   ╭─[source:3:30]
 2 │
 3 │ 0x[01 02] | deserialize { x: 'djakwl' }
   ·                              ────┬───
   ·                                  ╰── schema is malformed
   ╰────
  help: expected format to be {type}:{size}, found djakwl
```
---
```nushell
0x[01 02] | deserialize { x: { a: 'int:8', y: 'djakwl' } }
```
```
Error:   × invalid_schema
   ╭─[source:3:47]
 2 │
 3 │ 0x[01 02] | deserialize { x: { a: 'int:8', y: 'djakwl' } }
   ·                                               ────┬───
   ·                                                   ╰── schema is malformed
   ╰────
  help: expected format to be {type}:{size}, found djakwl
```
---
```nushell
123 | serialize 'djakwl'
```
```
Error:   × invalid_schema
   ╭─[source:3:17]
 2 │
 3 │ 123 | serialize 'djakwl'
   ·                 ────┬───
   ·                     ╰── schema is malformed
   ╰────
  help: expected format to be {type}:{size}, found djakwl
```
---
```nushell
123 | serialize 'djakwl:123'
```
```
Error:   × invalid_schema
   ╭─[source:3:17]
 2 │
 3 │ 123 | serialize 'djakwl:123'
   ·                 ──────┬─────
   ·                       ╰── schema is malformed
   ╰────
  help: expected size to be a multiple of 8, found 123
```
---
```nushell
123 | serialize 'vec:16'
```
```
Error:   × ser_vec::invalid_binary
   ╭─[source:3:17]
 2 │
 3 │ 123 | serialize 'vec:16'
   ·                 ────┬───
   ·                     ╰── some error
   ╰────
  help: expected a list<binary>, found int
```
---
```nushell
[0x[01 02], 0x[03]] | serialize 'vec:16'
```
```
Error:   × ser_vec::invalid_value
   ╭─[source:3:33]
 2 │
 3 │ [0x[01 02], 0x[03]] | serialize 'vec:16'
   ·                                 ────┬───
   ·                                     ╰── some error
   ╰────
  help: expected all items to be 2 bytes long, found 1 bytes at index 1
```
---
```nushell
{ x: 123 } | serialize { x: 'djakwl' }
```
```
Error:   × invalid_schema
   ╭─[source:3:24]
 2 │
 3 │ { x: 123 } | serialize { x: 'djakwl' }
   ·                        ───────┬───────
   ·                               ╰── schema is malformed
   ╰────
  help: expected format to be {type}:{size}, found djakwl
```
---
```nushell
{ x: { a: 123, y: 456 } } | serialize { x: { a: 'int:8', y: 'djakwl' } }
```
```
Error:   × invalid_schema
   ╭─[source:3:39]
 2 │
 3 │ { x: { a: 123, y: 456 } } | serialize { x: { a: 'int:8', y: 'djakwl' } }
   ·                                       ─────────────────┬────────────────
   ·                                                        ╰── schema is malformed
   ╰────
  help: expected format to be {type}:{size}, found djakwl
```
